### PR TITLE
add swapping for sword models

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -158,6 +158,7 @@ GameObject:
   m_Component:
   - component: {fileID: 267894039522821977}
   - component: {fileID: 8003555999151050329}
+  - component: {fileID: 5996568777664958275}
   m_Layer: 0
   m_Name: Sword
   m_TagString: Untagged
@@ -199,6 +200,21 @@ MonoBehaviour:
   swordAttackRange: 2
   swordCooldown: 1
   swordDamage: 5
+--- !u!114 &5996568777664958275
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3568323281790274878}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 13d3da9ffa3f52a4f8570c8f640935cc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Sword1: {fileID: 7415290259958409542}
+  Sword2: {fileID: 1900924684902164720}
+  Sword3: {fileID: 2619730773227688868}
 --- !u!1 &3949065781595635371
 GameObject:
   m_ObjectHideFlags: 0
@@ -828,6 +844,180 @@ MonoBehaviour:
   water: 100
   coinSound: {fileID: 0}
   waterText: {fileID: 0}
+--- !u!1001 &982036834404004980
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 4008659376260815378}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.014
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.014
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.014
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.00015
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0011
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.00061
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+      propertyPath: m_Name
+      value: sword2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+--- !u!4 &732499256002384799 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+  m_PrefabInstance: {fileID: 982036834404004980}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &1900924684902164720 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: 7700fe6718c8cdf4e95de6ee18f5671f, type: 3}
+  m_PrefabInstance: {fileID: 982036834404004980}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3718481134465044256
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 4008659376260815378}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.45
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.00019
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.00103
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+      propertyPath: m_Name
+      value: sword3
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+--- !u!23 &2619730773227688868 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+  m_PrefabInstance: {fileID: 3718481134465044256}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &3751511265205987531 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 3b70c8c4c5e78594fa98d7db5e8b542d, type: 3}
+  m_PrefabInstance: {fileID: 3718481134465044256}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4234498344303653858
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -894,13 +1084,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6641563682575669924, guid: 0a07f67ea8a0b8d4f815ec63442345e5, type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0a07f67ea8a0b8d4f815ec63442345e5, type: 3}
+--- !u!23 &7415290259958409542 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 6641563682575669924, guid: 0a07f67ea8a0b8d4f815ec63442345e5, type: 3}
+  m_PrefabInstance: {fileID: 4234498344303653858}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &8548759980556407337 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5503607822464655819, guid: 0a07f67ea8a0b8d4f815ec63442345e5, type: 3}
@@ -1000,6 +1195,12 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: -2293973760401034094, guid: 020bd025d5f76574d88de503f74b688c, type: 3}
       insertIndex: -1
       addedObject: {fileID: 8548759980556407337}
+    - targetCorrespondingSourceObject: {fileID: -2293973760401034094, guid: 020bd025d5f76574d88de503f74b688c, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 732499256002384799}
+    - targetCorrespondingSourceObject: {fileID: -2293973760401034094, guid: 020bd025d5f76574d88de503f74b688c, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3751511265205987531}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 020bd025d5f76574d88de503f74b688c, type: 3}
       insertIndex: -1

--- a/Assets/Scripts/Player/PlayerMovementController.cs
+++ b/Assets/Scripts/Player/PlayerMovementController.cs
@@ -55,7 +55,7 @@ public class PlayerMovementController : MonoBehaviour
     //Sword
     SwordTemplate _sword;
     Transform _swordTransform;
-    [SerializeField] GameObject SwordModel;
+    SwordModelSwapper swordModelSwapper;
 
     //for Weapon Switching, 0 is Gun and 1 is Sword
     int weapon = 0;
@@ -154,14 +154,14 @@ public class PlayerMovementController : MonoBehaviour
             {
                 weapon = 1;
                 GunModel.GetComponent<MeshRenderer>().enabled = false;
-                SwordModel.GetComponent<MeshRenderer>().enabled = true;
+                swordModelSwapper.enableRenderer();
                 AimRig.weight= 0f;
             }
             else if (weapon == 1)
             {
                 weapon = 0;
                 GunModel.GetComponent<MeshRenderer>().enabled = true;
-                SwordModel.GetComponent<MeshRenderer>().enabled = false;
+                swordModelSwapper.disableRenderer();
                 AimRig.weight = 1f;
             }
         };
@@ -185,6 +185,8 @@ public class PlayerMovementController : MonoBehaviour
     private void Start()
     {
         GameController.instance.PlayerDeath.AddListener(playerDeath);
+        swordModelSwapper = GetComponentInChildren<SwordModelSwapper>();
+        if(swordModelSwapper == null) { Debug.LogError("Failed to load SwordModelSwapper for Player."); }
     }
 
     private void OnEnable()

--- a/Assets/Scripts/Weapon/WeaponSwapping.meta
+++ b/Assets/Scripts/Weapon/WeaponSwapping.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f3f012cbb0a2cdc41bc818873d78d7ad
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Weapon/WeaponSwapping/SwordModelSwapper.cs
+++ b/Assets/Scripts/Weapon/WeaponSwapping/SwordModelSwapper.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SwordModelSwapper : MonoBehaviour
+{
+    [SerializeField] MeshRenderer Sword1;
+    [SerializeField] MeshRenderer Sword2;
+    [SerializeField] MeshRenderer Sword3;
+
+    Weapons.Swords _currentSword = Weapons.Swords.sword1;
+    private bool _isActive = false;
+
+    public void swapModel(Weapons.Swords sword)
+    {
+        _currentSword= sword;
+        if(_isActive)
+        {
+            disableAll();
+            switch (sword)
+            {
+                case Weapons.Swords.sword1:
+                    Sword1.enabled = true;
+                    break;
+                case Weapons.Swords.sword2:
+                    Sword2.enabled = true;
+                    break;
+                case Weapons.Swords.sword3:
+                    Sword3.enabled = true;
+                    break;
+            }
+        }  
+    }
+
+    public void enableRenderer()
+    {
+        _isActive = true;
+        swapModel(_currentSword);
+    }
+
+    public void disableRenderer()
+    {
+        disableAll();
+        _isActive = false;
+    }
+
+    private void Start()
+    {
+        if(Sword1 == null ||
+           Sword2 == null ||
+           Sword3 == null) {
+            Debug.LogError("SwordModelSwapper is missing Links in the inspector.");
+        }
+        disableAll();
+    }
+
+    private void disableAll()
+    {
+        Sword1.enabled = false;
+        Sword2.enabled = false;
+        Sword3.enabled = false;
+    }
+}

--- a/Assets/Scripts/Weapon/WeaponSwapping/SwordModelSwapper.cs
+++ b/Assets/Scripts/Weapon/WeaponSwapping/SwordModelSwapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 
 public class SwordModelSwapper : MonoBehaviour
@@ -60,5 +61,27 @@ public class SwordModelSwapper : MonoBehaviour
         Sword1.enabled = false;
         Sword2.enabled = false;
         Sword3.enabled = false;
+    }
+}
+
+[CustomEditor(typeof(SwordModelSwapper))]
+public class SwordModelSwapperEditor : Editor
+{
+    public override void OnInspectorGUI()
+    {
+        DrawDefaultInspector();
+        var swapper = (SwordModelSwapper)target;
+        if (GUILayout.Button("sword1"))
+        {
+            swapper.swapModel(Weapons.Swords.sword1);
+        }
+        else if (GUILayout.Button("sword2"))
+        {
+            swapper.swapModel(Weapons.Swords.sword2);
+        }
+        else if (GUILayout.Button("sword3"))
+        {
+            swapper.swapModel(Weapons.Swords.sword3);
+        }
     }
 }

--- a/Assets/Scripts/Weapon/WeaponSwapping/SwordModelSwapper.cs.meta
+++ b/Assets/Scripts/Weapon/WeaponSwapping/SwordModelSwapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13d3da9ffa3f52a4f8570c8f640935cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Weapon/WeaponSwapping/Weapons.cs
+++ b/Assets/Scripts/Weapon/WeaponSwapping/Weapons.cs
@@ -1,0 +1,10 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Weapons
+{
+    public enum Swords {
+        sword1, sword2, sword3
+    }
+}

--- a/Assets/Scripts/Weapon/WeaponSwapping/Weapons.cs.meta
+++ b/Assets/Scripts/Weapon/WeaponSwapping/Weapons.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1328430c092a1c42a6070e50af535c0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The player now holds 3 different sword models, the active model can be set through the SwordModelSwapper without messing directly with the mesh renderers. The Script is usable for Enemies as well.