### PR TITLE
Barrels ignite other barrels

### DIFF
--- a/Assets/Prefabs/Enemies/Barrel1.prefab
+++ b/Assets/Prefabs/Enemies/Barrel1.prefab
@@ -141,7 +141,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1b2ed60a0ca85f84b982838b2b02c024, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxHealth: 0
+  maxHealth: 1
   deathTimer: 0
   HitParticle: {fileID: 575812239389501723, guid: f0d8c38dec8e9544fbbac078e259b773, type: 3}
   healthbar: {fileID: 0}


### PR DESCRIPTION
Sets the maxHealth of the barrel prefab to 1 instead of 0 to enable barrels to ignite other barrels in range on explosion

Resolves #120 